### PR TITLE
Added extra logic so lexical environments are also cached and tied to…

### DIFF
--- a/AngleSharp.Scripting.JavaScript/ContextCache.cs
+++ b/AngleSharp.Scripting.JavaScript/ContextCache.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using Jint;
+using Jint.Runtime.Environments;
+
+namespace AngleSharp.Scripting.JavaScript
+{
+    internal class ContextCache
+    {
+        readonly Dictionary<object, DomNodeInstance> _objects = new Dictionary<object, DomNodeInstance>();
+        
+        internal LexicalEnvironment LexicalEnvironment { get; set; }
+        internal LexicalEnvironment VariableEnvironment { get; set; }
+
+        internal DomNodeInstance GetDomNodeInstance(Engine engine, object obj)
+        {
+            DomNodeInstance domNodeInstance;
+
+            if (_objects.TryGetValue(obj, out domNodeInstance))
+                return domNodeInstance;
+            
+            domNodeInstance = new DomNodeInstance(engine, obj);
+
+            _objects.Add(obj, domNodeInstance);
+
+            return domNodeInstance;
+        }
+    }
+}

--- a/AngleSharp.Scripting.JavaScript/DomNodeInstance.cs
+++ b/AngleSharp.Scripting.JavaScript/DomNodeInstance.cs
@@ -118,9 +118,9 @@
                     // If it already has a property with the given name (usually another method),
                     // then convert that method to a two-layer method, which decides which one
                     // to pick depending on the number (and probably types) of arguments.
-                    if (HasProperty(name))
+                    if (Properties.ContainsKey(name))
                         continue;
-
+                    
                     FastAddProperty(name, new DomFunctionInstance(this, method), false, false, false);
                 }
             }


### PR DESCRIPTION
… a specific IWindow instance.  Allows scripts to access functions defined outside of their own scope but in the same context.