### PR TITLE
Update to AngleSharp 0.9.4

### DIFF
--- a/AngleSharp.Scripting.JavaScript.Tests/packages.config
+++ b/AngleSharp.Scripting.JavaScript.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AngleSharp" version="0.9.2" targetFramework="net46" />
+  <package id="AngleSharp" version="0.9.4" targetFramework="net46" />
   <package id="Jint" version="2.6.0" targetFramework="net46" />
   <package id="NUnit" version="2.6.4" targetFramework="net46" />
   <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net46" />

--- a/AngleSharp.Scripting.JavaScript/Dom/XmlHttpRequest.cs
+++ b/AngleSharp.Scripting.JavaScript/Dom/XmlHttpRequest.cs
@@ -344,7 +344,7 @@
         {
             try
             {
-                using (var response = await loader.LoadAsync(request, cancel).ConfigureAwait(false))
+                using (var response = await loader.DownloadAsync(request).Task.ConfigureAwait(false))
                 {
                     if (response != null)
                     {

--- a/AngleSharp.Scripting.JavaScript/JavaScriptEngine.cs
+++ b/AngleSharp.Scripting.JavaScript/JavaScriptEngine.cs
@@ -40,7 +40,7 @@
         /// </summary>
         public String Type
         {
-            get { return MimeTypes.DefaultJavaScript; }
+            get { return MimeTypeNames.DefaultJavaScript; }
         }
 
         /// <summary>

--- a/AngleSharp.Scripting.JavaScript/ScriptingService.cs
+++ b/AngleSharp.Scripting.JavaScript/ScriptingService.cs
@@ -35,7 +35,7 @@
         /// <returns>The contained engine.</returns>
         public IScriptEngine GetEngine(String mimeType)
         {
-            if (MimeTypes.IsJavaScript(mimeType))
+            if (MimeTypeNames.IsJavaScript(mimeType))
                 return _engine;
 
             return null;

--- a/AngleSharp.Scripting.JavaScript/packages.config
+++ b/AngleSharp.Scripting.JavaScript/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AngleSharp" version="0.9.2" targetFramework="net45" />
+  <package id="AngleSharp" version="0.9.4" targetFramework="net45" />
   <package id="Jint" version="2.6.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I noticed when trying to use AngleSharp.Javascript i was encountering a runtime type load exception on MimeTypes. After some investigation i saw the name had been changed in AngleSharp 0.9.4. 

Updates Scripting.JavaScript to new naming and api changes

MimeTypes -> MimeTypeNames
IDocumentLoader.LoadAsync -> IDocumentLoader.DownloadAsync (also removed
cancelation token)