### PR TITLE
Make PrototypeCache thread-safe

### DIFF
--- a/src/AngleSharp.Scripting.CSharp/AngleSharp.Scripting.CSharp.csproj
+++ b/src/AngleSharp.Scripting.CSharp/AngleSharp.Scripting.CSharp.csproj
@@ -42,13 +42,13 @@
     <Compile Include="WindowContext.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="AngleSharp, Version=0.10.0.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
-      <HintPath>..\packages\AngleSharp.0.10.0\lib\portable-windows8+net45+windowsphone8+wpa+monoandroid+monotouch\AngleSharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <ProjectReference Include="..\..\..\AngleSharp\src\AngleSharp\AngleSharp.Core.csproj">
+      <Project>{91f78c48-287e-41b5-9e49-44d6e1e31290}</Project>
+      <Name>AngleSharp.Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/src/AngleSharp.Scripting.CSharp/packages.config
+++ b/src/AngleSharp.Scripting.CSharp/packages.config
@@ -1,4 +1,3 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AngleSharp" version="0.10.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>

--- a/src/AngleSharp.Scripting.JavaScript/AngleSharp.Scripting.JavaScript.csproj
+++ b/src/AngleSharp.Scripting.JavaScript/AngleSharp.Scripting.JavaScript.csproj
@@ -35,8 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="jint, Version=2.10.4.0, Culture=neutral, PublicKeyToken=2e92ba9c8d81157f, processorArchitecture=MSIL">
-      <HintPath>..\packages\jint.2.10.4\lib\portable40-net40+sl5+win8+wp8+wpa81\jint.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\..\src\packages\jint.2.10.4\lib\portable40-net40+sl5+win8+wp8+wpa81\jint.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Concurrent">
@@ -82,13 +81,13 @@
     <Compile Include="UnresolvedConverter.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\..\AngleSharp\src\AngleSharp\AngleSharp.Core.csproj">
       <Project>{91f78c48-287e-41b5-9e49-44d6e1e31290}</Project>
       <Name>AngleSharp.Core</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/src/AngleSharp.Scripting.JavaScript/AngleSharp.Scripting.JavaScript.csproj
+++ b/src/AngleSharp.Scripting.JavaScript/AngleSharp.Scripting.JavaScript.csproj
@@ -34,14 +34,14 @@
     <DocumentationFile>bin\Release\AngleSharp.Scripting.JavaScript.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AngleSharp, Version=0.10.0.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="jint, Version=2.10.4.0, Culture=neutral, PublicKeyToken=2e92ba9c8d81157f, processorArchitecture=MSIL">
       <HintPath>..\packages\jint.2.10.4\lib\portable40-net40+sl5+win8+wp8+wpa81\jint.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Concurrent">
+      <HintPath>..\..\..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETPortable\v4.5\Profile\Profile111\System.Collections.Concurrent.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Net" />
     <Reference Include="System.Xml.Linq" />
@@ -83,6 +83,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\AngleSharp\src\AngleSharp\AngleSharp.Core.csproj">
+      <Project>{91f78c48-287e-41b5-9e49-44d6e1e31290}</Project>
+      <Name>AngleSharp.Core</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/src/AngleSharp.Scripting.JavaScript/DomDelegates.cs
+++ b/src/AngleSharp.Scripting.JavaScript/DomDelegates.cs
@@ -26,7 +26,20 @@
 
         public static DomEventHandler ToListener(this FunctionInstance function, EngineInstance engine)
         {
-            return (obj, ev) => function.Call(obj.ToJsValue(engine), new [] { ev.ToJsValue(engine) });
+            return (obj, ev) =>
+            {
+                var objAsJs = obj.ToJsValue(engine);
+                var evAsJs = ev.ToJsValue(engine);
+
+                try
+                {   
+                    function.Call(objAsJs, new[] {evAsJs});
+                }
+                catch
+                {
+                    /* We omit failed 3rd party services */
+                }
+            };
         }
 
         public static T ToCallback<T>(this FunctionInstance function, EngineInstance engine)

--- a/src/AngleSharp.Scripting.JavaScript/PrototypeCache.cs
+++ b/src/AngleSharp.Scripting.JavaScript/PrototypeCache.cs
@@ -1,4 +1,6 @@
-﻿namespace AngleSharp.Scripting.JavaScript
+﻿using System.Collections.Concurrent;
+
+namespace AngleSharp.Scripting.JavaScript
 {
     using Jint;
     using Jint.Native.Object;
@@ -7,27 +9,21 @@
 
     sealed class PrototypeCache
     {
-        private readonly Dictionary<Type, ObjectInstance> _prototypes;
+        private readonly ConcurrentDictionary<Type, ObjectInstance> _prototypes;
         private readonly Engine _engine;
 
         public PrototypeCache(Engine engine)
         {
-            _prototypes = new Dictionary<Type, ObjectInstance>();
-            _prototypes.Add(typeof(Object), engine.Object.PrototypeObject);
+            _prototypes = new ConcurrentDictionary<Type, ObjectInstance>
+            {
+                [typeof(Object)] = engine.Object.PrototypeObject
+            };
             _engine = engine;
         }
 
         public ObjectInstance GetOrCreate(Type type, Func<Type, ObjectInstance> creator)
         {
-            var instance = default(ObjectInstance);
-
-            if (!_prototypes.TryGetValue(type, out instance))
-            {
-                instance = creator.Invoke(type);
-                _prototypes.Add(type, instance);
-            }
-
-            return instance;
+            return _prototypes.GetOrAdd(type, creator.Invoke);
         }
     }
 }

--- a/src/AngleSharp.Scripting.JavaScript/PrototypeCache.cs
+++ b/src/AngleSharp.Scripting.JavaScript/PrototypeCache.cs
@@ -1,11 +1,9 @@
-﻿using System.Collections.Concurrent;
-
-namespace AngleSharp.Scripting.JavaScript
+﻿namespace AngleSharp.Scripting.JavaScript
 {
     using Jint;
     using Jint.Native.Object;
     using System;
-    using System.Collections.Generic;
+    using System.Collections.Concurrent;
 
     sealed class PrototypeCache
     {

--- a/src/AngleSharp.Scripting.JavaScript/packages.config
+++ b/src/AngleSharp.Scripting.JavaScript/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AngleSharp" version="0.10.0" targetFramework="portable45-net45+win8+wp8+wpa81" />
   <package id="jint" version="2.10.4" targetFramework="portable45-net45+win8+wp8+wpa81" />
 </packages>


### PR DESCRIPTION
`ReferenceCache` seems to be thread-safe because `ConditionalWeakTable` is safe by default but I was getting "key already added" in ReferenceCache in a concurrent scenario.