### PR TITLE
Serialize DocumentReadyState

### DIFF
--- a/src/AngleSharp.Js/Extensions/EngineExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/EngineExtensions.cs
@@ -45,12 +45,16 @@ namespace AngleSharp.Js
                 }
                 else if (obj is Enum)
                 {
-                    string name = ((Enum)obj).GetOfficialName();
-                    if (name != null)
+                    switch (obj)
                     {
-                        return new JsValue(name);
+                        case DocumentReadyState _:
+                            string name = ((Enum)obj).GetOfficialName();
+                            if (name != null)
+                            {
+                                return new JsValue(name);
+                            }
+                            break;
                     }
-
                     return new JsValue(Convert.ToInt32(obj));
                 }
 

--- a/src/AngleSharp.Js/Extensions/EngineExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/EngineExtensions.cs
@@ -48,7 +48,7 @@ namespace AngleSharp.Js
                     switch (obj)
                     {
                         case DocumentReadyState _:
-                            string name = ((Enum)obj).GetOfficialName();
+                            var name = ((Enum)obj).GetOfficialName();
                             if (name != null)
                             {
                                 return new JsValue(name);

--- a/src/AngleSharp.Js/Extensions/EngineExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/EngineExtensions.cs
@@ -45,6 +45,12 @@ namespace AngleSharp.Js
                 }
                 else if (obj is Enum)
                 {
+                    string name = ((Enum)obj).GetOfficialName();
+                    if (name != null)
+                    {
+                        return new JsValue(name);
+                    }
+
                     return new JsValue(Convert.ToInt32(obj));
                 }
 

--- a/src/AngleSharp.Js/Extensions/ReflectionExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/ReflectionExtensions.cs
@@ -94,7 +94,7 @@ namespace AngleSharp.Js
 
             // if the enum value does not have a DomNameAttribute, calling member.GetOfficialName() would return the value name
             // to allow previous behaviour to be preserved, if the DomNameAttribute is not present then null will be returned
-            IEnumerable<DomNameAttribute> names = member.GetCustomAttributes<DomNameAttribute>();
+            var names = member.GetCustomAttributes<DomNameAttribute>();
             var officialNameAttribute = names.FirstOrDefault();
             return officialNameAttribute?.OfficialName;
         }

--- a/src/AngleSharp.Js/Extensions/ReflectionExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/ReflectionExtensions.cs
@@ -55,8 +55,8 @@ namespace AngleSharp.Js
         public static String GetOfficialName(this MemberInfo member)
         {
             var names = member.GetCustomAttributes<DomNameAttribute>();
-            var officalNameAttribute = names.FirstOrDefault();
-            return officalNameAttribute?.OfficialName ?? member.Name;
+            var officialNameAttribute = names.FirstOrDefault();
+            return officialNameAttribute?.OfficialName ?? member.Name;
         }
 
         public static String GetOfficialName(this Type currentType, Type baseType)
@@ -85,6 +85,18 @@ namespace AngleSharp.Js
             }
 
             return name;
+        }
+
+        public static String GetOfficialName(this Enum value)
+        {
+            var enumType = value.GetType();
+            var member = enumType.GetMember(value.ToString()).FirstOrDefault();
+
+            // if the enum value does not have a DomNameAttribute, calling member.GetOfficialName() would return the value name
+            // to allow previous behaviour to be preserved, if the DomNameAttribute is not present then null will be returned
+            IEnumerable<DomNameAttribute> names = member.GetCustomAttributes<DomNameAttribute>();
+            var officialNameAttribute = names.FirstOrDefault();
+            return officialNameAttribute?.OfficialName;
         }
 
         public static PropertyInfo GetInheritedProperty(this Type type, String propertyName, BindingFlags bindingAttr = BindingFlags.Public | BindingFlags.Instance)


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [X] I have read the **CONTRIBUTING** document
- [X] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## Description

Serializes the `DocumentReadyState` enum for `document.readyState` based on the `DomNameAttribute.OfficialName` value if available.
Serializing other enum types has been left open, as too many tests/intended functionality breaks otherwise.

The serialized values are only available when AngleSharp v1.0.2 or greater is installed, otherwise previous behaviour is preserved.


Addresses #86 