### PR TITLE
Added Image constructor support

### DIFF
--- a/src/AngleSharp.Js.Tests/ScriptEvalTests.cs
+++ b/src/AngleSharp.Js.Tests/ScriptEvalTests.cs
@@ -76,6 +76,13 @@ namespace AngleSharp.Js.Tests
         }
 
         [Test]
+        public async Task CreateImageShouldWork()
+        {
+            var result = await EvaluateComplexScriptAsync("var img = new Image(400, 200); img.src = '/image.jpg';", SetResult("img.width"));
+            Assert.AreEqual("400", result);
+        }
+
+        [Test]
         public async Task PerformXmlHttpRequestSynchronousToDataUrlShouldWork()
         {
             var req = new DataRequester();

--- a/src/AngleSharp.Js/Attributes/DomConstructorFunctionAttribute.cs
+++ b/src/AngleSharp.Js/Attributes/DomConstructorFunctionAttribute.cs
@@ -1,0 +1,28 @@
+namespace AngleSharp.Js.Attributes
+{
+    using System;
+
+    /// <summary>
+    /// This attribute is used to mark a method to be uses as a
+    /// constructor function from scripts.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed class DomConstructorFunctionAttribute : Attribute
+    {
+        /// <summary>
+        /// Creates a new DomConstructorFunctionAttribute.
+        /// </summary>
+        /// <param name="officialName">
+        /// The official name of the decorated method.
+        /// </param>
+        public DomConstructorFunctionAttribute(String officialName)
+        {
+            OfficialName = officialName;
+        }
+
+        /// <summary>
+        /// Gets the official name of the given class.
+        /// </summary>
+        public String OfficialName { get; }
+    }
+}

--- a/src/AngleSharp.Js/Dom/WindowExtensions.cs
+++ b/src/AngleSharp.Js/Dom/WindowExtensions.cs
@@ -4,6 +4,8 @@ namespace AngleSharp.Js.Dom
     using AngleSharp.Browser;
     using AngleSharp.Dom;
     using AngleSharp.Dom.Events;
+    using AngleSharp.Html.Dom;
+    using AngleSharp.Js.Attributes;
     using System;
 
     /// <summary>
@@ -41,6 +43,31 @@ namespace AngleSharp.Js.Dom
         public static Console Console(this IWindow window)
         {
             return new Console(window);
+        }
+
+        /// <summary>
+        /// Creates a new IHtmlImageElement instance.
+        /// </summary>
+        /// <param name="window"></param>
+        /// <param name="width"></param>
+        /// <param name="height"></param>
+        /// <returns></returns>
+        [DomConstructorFunction("Image")]
+        public static IHtmlImageElement Image(this IWindow window, int? width = null, int? height = null)
+        {
+            var imageElement = window.Document.CreateElement(TagNames.Img) as IHtmlImageElement;
+
+            if (width.HasValue)
+            {
+                imageElement.DisplayWidth = width.Value;
+            }
+
+            if (height.HasValue)
+            {
+                imageElement.DisplayHeight = height.Value;
+            }
+
+            return imageElement;
         }
     }
 }

--- a/src/AngleSharp.Js/EngineInstance.cs
+++ b/src/AngleSharp.Js/EngineInstance.cs
@@ -47,6 +47,7 @@ namespace AngleSharp.Js
             foreach (var lib in libs)
             {
                 this.AddConstructors(_window, lib);
+                this.AddConstructorFunctions(_window, lib);
                 this.AddInstances(_window, lib);
             }
 

--- a/src/AngleSharp.Js/Extensions/EngineExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/EngineExtensions.cs
@@ -178,6 +178,14 @@ namespace AngleSharp.Js
             }
         }
 
+        public static void AddConstructorFunctions(this EngineInstance engine, ObjectInstance ctx, Assembly assembly)
+        {
+            foreach (var exportedType in assembly.ExportedTypes)
+            {
+                engine.AddConstructorFunction(ctx, exportedType);
+            }
+        }
+
         public static void AddInstances(this EngineInstance engine, ObjectInstance obj, Assembly assembly)
         {
             foreach (var exportedType in assembly.ExportedTypes)
@@ -189,6 +197,12 @@ namespace AngleSharp.Js
         public static void AddConstructor(this EngineInstance engine, ObjectInstance obj, Type type)
         {
             var apply = type.GetConstructorAction();
+            apply.Invoke(engine, obj);
+        }
+
+        public static void AddConstructorFunction(this EngineInstance engine, ObjectInstance obj, Type type)
+        {
+            var apply = type.GetConstructorFunctionAction();
             apply.Invoke(engine, obj);
         }
 

--- a/src/AngleSharp.Js/Extensions/JsValueExtensions.cs
+++ b/src/AngleSharp.Js/Extensions/JsValueExtensions.cs
@@ -73,6 +73,17 @@ namespace AngleSharp.Js
                 {
                     return TypeConverter.ToInt32(value);
                 }
+                else if (targetType == typeof(Nullable<Int32>))
+                {
+                    if (value.IsUndefined())
+                    {
+                        return null;
+                    }
+                    else
+                    {
+                        return TypeConverter.ToInt32(value);
+                    }
+                }
                 else if (targetType == typeof(Double))
                 {
                     return TypeConverter.ToNumber(value);

--- a/src/AngleSharp.Js/Proxies/DomConstructorFunctionInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomConstructorFunctionInstance.cs
@@ -1,0 +1,31 @@
+namespace AngleSharp.Js.Proxies
+{
+    using Jint.Native;
+    using Jint.Native.Object;
+    using Jint.Runtime;
+    using System.Reflection;
+
+    sealed class DomConstructorFunctionInstance : Constructor
+    {
+        private readonly EngineInstance _instance;
+        private readonly MethodInfo _constructorFunction;
+
+        public DomConstructorFunctionInstance(EngineInstance instance, MethodInfo constructorFunction, string name) : base(instance.Jint, name)
+        {
+            _instance = instance;
+            _constructorFunction = constructorFunction;
+        }
+
+        public override ObjectInstance Construct(JsValue[] arguments, JsValue newTarget)
+        {
+            try
+            {
+                return _instance.Call(_constructorFunction, _instance.Window, arguments) as DomNodeInstance;
+            }
+            catch
+            {
+                throw new JavaScriptException(_instance.Jint.Intrinsics.Error);
+            }
+        }
+    }
+}

--- a/src/AngleSharp.Js/Proxies/DomConstructorFunctionInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomConstructorFunctionInstance.cs
@@ -20,7 +20,7 @@ namespace AngleSharp.Js.Proxies
         {
             try
             {
-                return _instance.Call(_constructorFunction, _instance.Window, arguments) as DomNodeInstance;
+                return _instance.Call(_constructorFunction, _instance.Window, arguments) as ObjectInstance;
             }
             catch
             {


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [x] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

This PR adds support for the `Image` constructor as described [here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image).

Since this constructor does not directly link to the `HTMLImageElement` constructor, I have added a new "constructor function" way of adding constructors to the `Window` object:
- Added `DomConstructorFunctionInstance` which stores a reference to the constructor function and calls it when Jint calls the `Construct` function.
- Added `DomConstructorFunctionAttribute` to decorate any methods that need to be treated as a constructor function.
- Added methods in the `EngineExtensions`, `EngineInstance` and `CreatorCache` to find any decorated constructor functions and add them to the `Window` object.
- Added new extension method to `WindowExtensions` which handles the `Image` constructor call and returns a new `IHtmlImageElement` instance.
- Added unit test to test new `Image` constructor.
