### PR TITLE
IN operator now returns false if string indexer is used to search for property and returns null

### DIFF
--- a/src/AngleSharp.Js.Tests/OperatorsTests.cs
+++ b/src/AngleSharp.Js.Tests/OperatorsTests.cs
@@ -1,0 +1,47 @@
+namespace AngleSharp.Js.Tests
+{
+    using NUnit.Framework;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class OperatorsTests
+    {
+        [Test]
+        public async Task InOperatorExistingAttribute()
+        {
+
+            var result = await "'action' in document.createElement('form')".EvalScriptAsync();
+            Assert.AreEqual("True", result);
+        }
+
+        [Test]
+        public async Task InOperatorNonExistingAttribute()
+        {
+
+            var result = await "'action' in document.createElement('div')".EvalScriptAsync();
+            Assert.AreEqual("False", result);
+        }
+
+        [Test]
+        public async Task InOperatorInputWithinForm()
+        {
+            var result = await "'input1' in new DOMParser().parseFromString(`<form><input name='input1'/></form>`, 'text/html').body.firstChild".EvalScriptAsync();
+            Assert.AreEqual("True", result);
+        }
+
+        [Test]
+        public async Task InOperatorInputWithinDiv()
+        {
+            var result = await "'input1' in new DOMParser().parseFromString(`<div><input name='input1'/></div>`, 'text/html').body.firstChild".EvalScriptAsync();
+            Assert.AreEqual("False", result);
+        }
+
+        [Test]
+        public async Task InOperator_Issue104()
+        {
+            var result = await "'somethingThatDoesntExist' in document.createElement('form')".EvalScriptAsync();
+            Assert.AreEqual("False", result);
+        }
+
+    }
+}

--- a/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
+++ b/src/AngleSharp.Js/Proxies/DomPrototypeInstance.cs
@@ -70,7 +70,15 @@ namespace AngleSharp.Js
             if (_stringIndexer != null && !HasProperty(index))
             {
                 var args = new Object[] { index };
-                var prop = _stringIndexer.GetMethod.Invoke(value, args).ToJsValue(_instance);
+                var valueAtIndex = _stringIndexer.GetMethod.Invoke(value, args);
+
+                if (valueAtIndex == null)
+                {
+                    result = PropertyDescriptor.Undefined;
+                    return false;
+                }
+
+                var prop = valueAtIndex.ToJsValue(_instance);
                 result = new PropertyDescriptor(prop, false, false, false);
                 return true;
             }


### PR DESCRIPTION
# Types of Changes

## Prerequisites

Please make sure you can check the following two boxes:

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project

## Contribution Type

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue, please reference the issue id)
- [ ] New feature (non-breaking change which adds functionality, make sure to open an associated issue first)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## Description

Fixes #104.

When IN operator is used to search for property in an object and that object doesn't have the property, but has string indexer, then the indexer is used to look for property. Before fix, even if indexer returned null, i.e. "doesn't exist", IN returned true.

A few additional tests for IN operator were added as well, just to be sure if this change didn't break anything.